### PR TITLE
Fix a plugin installation problem

### DIFF
--- a/PowerEditor/src/EncodingMapper.h
+++ b/PowerEditor/src/EncodingMapper.h
@@ -26,8 +26,7 @@
 // Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
 
 
-#ifndef ENCODINGMAPPER_H
-#define ENCODINGMAPPER_H
+#pragma once
 
 struct EncodingUnit {
    int _codePage;
@@ -48,4 +47,3 @@ private:
     EncodingUnit *_encodings;
 };
 
-#endif // ENCODINGMAPPER_H

--- a/PowerEditor/src/NppBigSwitch.cpp
+++ b/PowerEditor/src/NppBigSwitch.cpp
@@ -2263,10 +2263,10 @@ LRESULT Notepad_plus::process(HWND hwnd, UINT message, WPARAM wParam, LPARAM lPa
 			return _pFileSwitcherPanel->isVisible();
 		}
 
-		case NPPM_GETAPPDATAPLUGINSALLOWED:
-		{
+		case NPPM_GETAPPDATAPLUGINSALLOWED: // if doLocal, it's always false - having doLocal environment cannot load plugins outside
+		{                                   // the presence of file "allowAppDataPlugins.xml" will be checked only when not doLocal
 			const TCHAR *appDataNpp = pNppParam->getAppDataNppDir();
-			if (appDataNpp[0])
+			if (appDataNpp[0]) // if not doLocal
 			{
 				generic_string allowAppDataPluginsPath(pNppParam->getNppPath());
 				PathAppend(allowAppDataPluginsPath, allowAppDataPluginsFile);

--- a/PowerEditor/src/Parameters.cpp
+++ b/PowerEditor/src/Parameters.cpp
@@ -890,14 +890,20 @@ bool NppParameters::reloadStylers(TCHAR* stylePath)
 	bool loadOkay = _pXmlUserStylerDoc->LoadFile();
 	if (!loadOkay)
 	{
-		_pNativeLangSpeaker->messageBox("LoadStylersFailed",
-			NULL,
-			TEXT("Load \"$STR_REPLACE$\" failed!"),
-			TEXT("Load stylers.xml failed"),
-			MB_OK,
-			0,
-			stylePathToLoad);
-
+		if (!_pNativeLangSpeaker)
+		{
+			::MessageBox(NULL, stylePathToLoad, TEXT("Load stylers.xml failed"), MB_OK);
+		}
+		else
+		{
+			_pNativeLangSpeaker->messageBox("LoadStylersFailed",
+				NULL,
+				TEXT("Load \"$STR_REPLACE$\" failed!"),
+				TEXT("Load stylers.xml failed"),
+				MB_OK,
+				0,
+				stylePathToLoad);
+		}
 		delete _pXmlUserStylerDoc;
 		_pXmlUserStylerDoc = NULL;
 		return false;
@@ -1079,12 +1085,23 @@ bool NppParameters::load()
 		WIN32_FILE_ATTRIBUTE_DATA attributes;
 
 		if (GetFileAttributesEx(langs_xml_path.c_str(), GetFileExInfoStandard, &attributes) != 0)
+		{
 			if (attributes.nFileSizeLow == 0 && attributes.nFileSizeHigh == 0)
-				doRecover = _pNativeLangSpeaker->messageBox("LoadLangsFailed",
-					NULL,
-					TEXT("Load langs.xml failed!\rDo you want to recover your langs.xml?"),
-					TEXT("Configurator"),
-					MB_YESNO);
+			{
+				if (_pNativeLangSpeaker)
+				{
+					doRecover = _pNativeLangSpeaker->messageBox("LoadLangsFailed",
+						NULL,
+						TEXT("Load langs.xml failed!\rDo you want to recover your langs.xml?"),
+						TEXT("Configurator"),
+						MB_YESNO);
+				}
+				else
+				{
+					doRecover = ::MessageBox(NULL, TEXT("Load langs.xml failed!\rDo you want to recover your langs.xml?"), TEXT("Configurator"), MB_YESNO);
+				}
+			}
+		}
 	}
 	else
 		doRecover = true;
@@ -1102,11 +1119,18 @@ bool NppParameters::load()
 	bool loadOkay = _pXmlDoc->LoadFile();
 	if (!loadOkay)
 	{
-		_pNativeLangSpeaker->messageBox("LoadLangsFailedFinal",
-			NULL,
-			TEXT("Load langs.xml failed!"),
-			TEXT("Configurator"),
-			MB_OK);
+		if (_pNativeLangSpeaker)
+		{
+			_pNativeLangSpeaker->messageBox("LoadLangsFailedFinal",
+				NULL,
+				TEXT("Load langs.xml failed!"),
+				TEXT("Configurator"),
+				MB_OK);
+		}
+		else
+		{
+			::MessageBox(NULL, TEXT("Load langs.xml failed!"), TEXT("Configurator"), MB_OK);
+		}
 
 		delete _pXmlDoc;
 		_pXmlDoc = nullptr;
@@ -1163,14 +1187,20 @@ bool NppParameters::load()
 	loadOkay = _pXmlUserStylerDoc->LoadFile();
 	if (!loadOkay)
 	{
-		_pNativeLangSpeaker->messageBox("LoadStylersFailed",
-			NULL,
-			TEXT("Load \"$STR_REPLACE$\" failed!"),
-			TEXT("Load stylers.xml failed"),
-			MB_OK,
-			0,
-			_stylerPath.c_str());
-
+		if (_pNativeLangSpeaker)
+		{
+			_pNativeLangSpeaker->messageBox("LoadStylersFailed",
+				NULL,
+				TEXT("Load \"$STR_REPLACE$\" failed!"),
+				TEXT("Load stylers.xml failed"),
+				MB_OK,
+				0,
+				_stylerPath.c_str());
+		}
+		else
+		{
+			::MessageBox(NULL, _stylerPath.c_str(), TEXT("Load stylers.xml failed"), MB_OK);
+		}
 		delete _pXmlUserStylerDoc;
 		_pXmlUserStylerDoc = NULL;
 		isAllLaoded = false;

--- a/PowerEditor/src/WinControls/FileBrowser/fileBrowser.h
+++ b/PowerEditor/src/WinControls/FileBrowser/fileBrowser.h
@@ -26,8 +26,7 @@
 // Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
 
 
-#ifndef FILEBROWSER_H
-#define  FILEBROWSER_H
+#pragma once
 
 //#include <windows.h>
 #ifndef DOCKINGDLGINTERFACE_H
@@ -179,5 +178,3 @@ protected:
 	void getDirectoryStructure(const TCHAR *dir, const std::vector<generic_string> & patterns, FolderInfo & directoryStructure, bool isRecursive, bool isInHiddenDir); 
 	HTREEITEM createFolderItemsFromDirStruct(HTREEITEM hParentItem, const FolderInfo & directoryStructure);
 };
-
-#endif // FILEBROWSER_H

--- a/PowerEditor/src/WinControls/PluginsAdmin/pluginsAdmin.cpp
+++ b/PowerEditor/src/WinControls/PluginsAdmin/pluginsAdmin.cpp
@@ -384,8 +384,18 @@ bool PluginsAdminDlg::installPlugins()
 	vector<PluginUpdateInfo*> puis = _availableList.fromUiIndexesToPluginInfos(indexes);
 
 	generic_string updaterParams = TEXT("-unzipTo ");
+	NppParameters *pNppParameters = NppParameters::getInstance();
+	generic_string nppPluginsDir;
 
-	generic_string nppPluginsDir = NppParameters::getInstance()->getUserPath();
+	if (pNppParameters->isLocal())
+	{
+		nppPluginsDir = pNppParameters->getNppPath();
+	}
+	else
+	{
+		nppPluginsDir = pNppParameters->getLocalAppDataNppDir();
+	}
+
 	PathAppend(nppPluginsDir, TEXT("plugins"));
 
 	if (!::PathFileExists(nppPluginsDir.c_str()))
@@ -393,13 +403,13 @@ bool PluginsAdminDlg::installPlugins()
 		::CreateDirectory(nppPluginsDir.c_str(), NULL);
 	}
 
+	generic_string quoted_nppPluginsDir = TEXT("\"");
+	quoted_nppPluginsDir += nppPluginsDir;
+	quoted_nppPluginsDir += TEXT("\"");
+
 	for (auto i : puis)
 	{
-		// add folder to operate
-		generic_string destFolder = nppPluginsDir;
-		PathAppend(destFolder, i->_folderName);
-		
-		updaterParams += destFolder;
+		updaterParams += quoted_nppPluginsDir;
 
 		// add zipFile's url
 		updaterParams += TEXT(" ");
@@ -407,8 +417,6 @@ bool PluginsAdminDlg::installPlugins()
 
 		Process updater(_updaterFullPath.c_str(), updaterParams.c_str(), _updaterDir.c_str());
 
-		printStr(updaterParams.c_str());
-		printStr(_updaterDir.c_str());
 		int result = updater.runSync();
 		if (result == 0) // wingup return 0 -> OK
 		{


### PR DESCRIPTION
Add a new plugins loadding behaviour:
if it's not doLocalConf mode, then plugins can be loadded from "AppData\Local\Notepad++\plugins\", without presence of "allowAppDataPlugins.xml".